### PR TITLE
Use proper format for WP-CLI's add_command

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,4 +13,5 @@ parameters:
         - %currentWorkingDirectory%/tests/phpstan/wp-cli-stubs-2.2.0.php
     ignoreErrors:
         - '#[a-zA-Z0-9\\_]+superglobal[a-zA-Z0-9\\_]+#'
-    excludes_analyse:
+        # WP-CLI accepts a class as callable
+        - '/^Parameter #2 \$callable of static method WP_CLI::add_command\(\) expects callable\(\): mixed, \S+ given\.$/'

--- a/static-html-output-plugin.php
+++ b/static-html-output-plugin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Plugin Name: Static HTML Output
  * Plugin URI:  https://statichtmloutput.com
@@ -11,9 +12,7 @@
  * @package     WP_Static_HTML_Output
  */
 
-
-
-if ( ! defined( 'WPINC' ) ) {
+if ( ! defined( 'ABSPATH' ) ) {
     die;
 }
 
@@ -46,7 +45,7 @@ if ( $export_log ) {
         echo "$log_row->time \t $log_row->log \t" . PHP_EOL;
     }
 
-    return null;
+    return;
 }
 
 if ( $crawl_log ) {
@@ -322,7 +321,6 @@ add_action( 'wp_footer', 'wp_static_html_output_deregister_scripts' );
 remove_action( 'wp_head', 'wlwmanifest_link' );
 
 if ( defined( 'WP_CLI' ) ) {
-    // @phpstan-ignore-next-line
-    WP_CLI::add_command( 'statichtmloutput', 'StaticHTMLOutput\CLI' );
-    WP_CLI::add_command( 'statichtmloutput options', [ 'StaticHTMLOutput\CLI', 'options' ] );
+    WP_CLI::add_command( 'statichtmloutput', StaticHTMLOutput\CLI::class );
+    WP_CLI::add_command( 'statichtmloutput options', [ StaticHTMLOutput\CLI::class, 'options' ] );
 }


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/blob/d7df11b43e9ece6990ac42371aadac2cbd9d6554/php/class-wp-cli.php#L450
and https://github.com/szepeviktor/phpstan-wordpress/blob/6195a6a19830d5ad187df0a3fb350e77cd571a5f/example/phpstan-full.neon#L38-L39

From https://github.com/leonstafford/static-html-output/commit/ba9fa5b27a31d9a67c1aeb320b2070c59c9fc7c7